### PR TITLE
Small fixes

### DIFF
--- a/sslcert_expiredate.sh
+++ b/sslcert_expiredate.sh
@@ -5,7 +5,7 @@ if [ "${#}" -ne 2 ] ; then
 	echo 'Invalid number of arguments given, the first argument should be a domain name, the second one the type of check you want to perform' 1>&2
 	exit 1
 # Check if the specified check is a portnummer in /etc/services
-elif [ -z "$(grep "^${2} " /etc/services)" ] ; then
+elif [ -z "$(grep "^${2}[[:blank:]]" /etc/services)" ] ; then
 	echo "Unsupported check '${2}' specified, please specify a portname from /etc/services" 1>&2
 	exit 2
 fi

--- a/sslcert_secondsvalid.sh
+++ b/sslcert_secondsvalid.sh
@@ -5,7 +5,7 @@ if [ "${#}" -ne 2 ] ; then
 	echo 'Invalid number of arguments given, the first argument should be a domain name, the second one the type of check you want to perform' 1>&2
 	exit 1
 # Check if the specified check is a portnummer in /etc/services
-elif [ -z "$(grep "^${2} " /etc/services)" ] ; then
+elif [ -z "$(grep "^${2}[[:blank:]]" /etc/services)" ] ; then
 	echo "Unsupported check '${2}' specified, please specify a portname from /etc/services" 1>&2
 	exit 2
 fi

--- a/sslcert_serial.sh
+++ b/sslcert_serial.sh
@@ -5,7 +5,7 @@ if [ "${#}" -ne 2 ] ; then
 	echo 'Invalid number of arguments given, the first argument should be a domain name, the second one the type of check you want to perform' 1>&2
 	exit 1
 # Check if the specified check is a portnummer in /etc/services
-elif [ -z "$(grep "^${2} " /etc/services)" ] ; then
+elif [ -z "$(grep "^${2}[[:blank:]]" /etc/services)" ] ; then
 	echo "Unsupported check '${2}' specified, please specify a portname from /etc/services" 1>&2
 	exit 2
 fi

--- a/zabbix_ssl_cert_discovery.sh
+++ b/zabbix_ssl_cert_discovery.sh
@@ -32,7 +32,7 @@ function to_json_objects() {
 
 	# Find the certificates for Apache, if it is installed
 	if [ -n "${apacheconfdir}" ] ; then
-		to_json_objects "$(grep -r SSLCertificateFile "${apacheconfdir}" 2> /dev/null | grep -v 'default-ssl.conf' | awk '!/#/ {print $3}' | sort | uniq)" https
+		to_json_objects "$(grep -R SSLCertificateFile "${apacheconfdir}" 2> /dev/null | grep -v 'default-ssl.conf' | awk '!/#/ {print $3}' | sort | uniq)" https
 	fi
 
 	#########
@@ -40,7 +40,7 @@ function to_json_objects() {
 	#########
 	# Find the certificates for Nginx, if it is installed
 	if [ -d "/etc/nginx" ] ; then
-		to_json_objects "$(grep -r ssl_certificate /etc/nginx/ 2> /dev/null | awk '!/ssl_certificate_key/ {print $3}' | sed 's/;$//' | sort | uniq)" https
+		to_json_objects "$(grep -R ssl_certificate /etc/nginx/ 2> /dev/null | awk '!/ssl_certificate_key/ {print $3}' | sed 's/;$//' | sort | uniq)" https
 	fi
 
 	# JSON end


### PR DESCRIPTION
1. Use grep -R to looking for strings in symbolic-link directories.
2. Use [[:blank:]] in grep to parse /etc/hosts, becaouse this works in Ubuntu. 